### PR TITLE
Fix typo in  03-Semantics-Variables.ipynb

### DIFF
--- a/03-Semantics-Variables.ipynb
+++ b/03-Semantics-Variables.ipynb
@@ -228,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When we call ``x += 5``, we are not modifying the value of the ``5`` object pointed to by ``x``, but rather we are changing the object to which ``x`` points.\n",
+    "When we call ``x += 5``, we are not modifying the value of the ``10`` object pointed to by ``x``, but rather we are changing the object to which ``x`` points.\n",
     "For this reason, the value of ``y`` is not affected by the operation."
    ]
   },


### PR DESCRIPTION
@jakevdp - First of all - thank you for writing and sharing these notebooks!
We'll be teaching a Python bootcamp to astronomers in 2 weeks and plan to use your materials.

This PR fixes a typo in the 03-Semantics-Variables.ipynb notebook at the very end of this section:
http://nbviewer.jupyter.org/github/jakevdp/WhirlwindTourOfPython/blob/master/03-Semantics-Variables.ipynb#Python-Variables-Are-Pointers

---

The current sentence is:

> When we call x += 5, we are not modifying the value of the 5 object pointed to by x, but rather we are changing the object to which x points. For this reason, the value of y is not affected by the operation.

I wonder if this could be made clearer by adding in "new int object with value 15", i.e. something like

> When we call x += 5, we are not modifying the value of the 10 object pointed to by x, but rather we are creating a new integer object with value 15, and change the x variable to point to that new object. For this reason, the value of y is not affected by the operation.

I didn't make the change here, because I wasn't sure it's better, so I just fixed the typo.