### PR TITLE
Order of Outputs 19 and 20

### DIFF
--- a/08-Defining-Functions.ipynb
+++ b/08-Defining-Functions.ipynb
@@ -544,9 +544,9 @@
     {
      "data": {
       "text/plain": [
-       "[{'YOB': 1912, 'first': 'Alan', 'last': 'Turing'},\n",
-       " {'YOB': 1906, 'first': 'Grace', 'last': 'Hopper'},\n",
-       " {'YOB': 1956, 'first': 'Guido', 'last': 'Van Rossum'}]"
+       "[{'first': 'Alan', 'last': 'Turing', 'YOB': 1912},\n",
+       " {'first': 'Grace', 'last': 'Hopper', 'YOB': 1906},\n",
+       " {'first': 'Guido', 'last': 'Van Rossum', 'YOB': 1956}]"
       ]
      },
      "execution_count": 19,
@@ -569,9 +569,9 @@
     {
      "data": {
       "text/plain": [
-       "[{'YOB': 1906, 'first': 'Grace', 'last': 'Hopper'},\n",
-       " {'YOB': 1912, 'first': 'Alan', 'last': 'Turing'},\n",
-       " {'YOB': 1956, 'first': 'Guido', 'last': 'Van Rossum'}]"
+       "[{'first': 'Grace', 'last': 'Hopper', 'YOB': 1906},\n",
+       " {'first': 'Alan', 'last': 'Turing', 'YOB': 1912},\n",
+       " {'first': 'Guido', 'last': 'Van Rossum', 'YOB': 1956}]"
       ]
      },
      "execution_count": 20,


### PR DESCRIPTION
The object "data" defined in input 17 has the dictionary organized in the order first, last, YOB, however, the outputs for 19 and 20 have YOB listed first. This proposed change reorganizes output 18 and 19 to reflect the output you would receive if you were to rerun the Jupyter notebook