### PR TITLE
Update URL for Dive Into Python

### DIFF
--- a/16-Further-Resources.ipynb
+++ b/16-Further-Resources.ipynb
@@ -37,7 +37,7 @@
     "If you'd like to go deeper in understanding the Python language itself and how to use it effectively, here are a handful of resources I'd recommend:\n",
     "\n",
     "- [*Fluent Python*](http://shop.oreilly.com/product/0636920032519.do) by Luciano Ramalho. This is an excellent OReilly book that explores best practices and idioms for Python, including getting the most out of the standard library.\n",
-    "- [*Dive Into Python*](http://www.diveintopython.net/) by Mark Pilgrim. This is a free online book that provides a ground-up introduction to the Python language.\n",
+    "- [*Dive Into Python*](https://diveintopython3.problemsolving.io/) by Mark Pilgrim. This is a free online book that provides a ground-up introduction to the Python language.\n",
     "- [*Learn Python the Hard Way*](http://learnpythonthehardway.org/) by Zed Shaw. This book follows a \"learn by trying\" approach, and deliberately emphasizes developing what may be the most useful skill a programmer can learn: Googling things you don't understand.\n",
     "- [*Python Essential Reference*](http://www.dabeaz.com/per.html) by David Beazley. This 700-page monster is well-written, and covers virtually everything there is to know about the Python language and its built-in libraries. For a more application-focused Python walk-through, see Beazley's [*Python Cookbook*](http://shop.oreilly.com/product/0636920027072.do).\n",
     "\n",


### PR DESCRIPTION
The URL for _Dive Into Python_ by Mark Pilgrim points `http://diveintopython.net/` which seems to be a website about sports betting and in a foreign language. 

Suggested changing it to `https://diveintopython3.problemsolving.io/`