### PR TITLE
Added examples of f-string usage in 'Strings-and-Regular-Expressions.ipynb'

### DIFF
--- a/14-Strings-and-Regular-Expressions.ipynb
+++ b/14-Strings-and-Regular-Expressions.ipynb
@@ -45,14 +45,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "True"
       ]
      },
-     "execution_count": 1,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 1
     }
    ],
    "source": [
@@ -137,14 +137,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'THE QUICK BROWN FOX.'"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 4
     }
    ],
    "source": [
@@ -159,14 +159,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'the quick brown fox.'"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 5
     }
    ],
    "source": [
@@ -189,14 +189,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'The Quick Brown Fox.'"
       ]
      },
-     "execution_count": 6,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 6
     }
    ],
    "source": [
@@ -211,14 +211,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'The quick brown fox.'"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 7
     }
    ],
    "source": [
@@ -240,14 +240,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'ThE QuicK BrowN FoX.'"
       ]
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 8
     }
    ],
    "source": [
@@ -272,14 +272,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'this is the content'"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 9
     }
    ],
    "source": [
@@ -302,14 +302,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'         this is the content'"
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 10
     }
    ],
    "source": [
@@ -324,14 +324,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'this is the content         '"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 11
     }
    ],
    "source": [
@@ -353,14 +353,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'435'"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 12
     }
    ],
    "source": [
@@ -385,14 +385,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'     this is the content      '"
       ]
      },
-     "execution_count": 13,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 13
     }
    ],
    "source": [
@@ -415,14 +415,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'this is the content           '"
       ]
      },
-     "execution_count": 14,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 14
     }
    ],
    "source": [
@@ -437,14 +437,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'           this is the content'"
       ]
      },
-     "execution_count": 15,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 15
     }
    ],
    "source": [
@@ -467,14 +467,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'0000000435'"
       ]
      },
-     "execution_count": 16,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 16
     }
    ],
    "source": [
@@ -496,14 +496,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'0000000435'"
       ]
      },
-     "execution_count": 17,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 17
     }
    ],
    "source": [
@@ -529,14 +529,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "16"
       ]
      },
-     "execution_count": 18,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 18
     }
    ],
    "source": [
@@ -552,14 +552,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "16"
       ]
      },
-     "execution_count": 19,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 19
     }
    ],
    "source": [
@@ -581,14 +581,14 @@
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "-1"
       ]
      },
-     "execution_count": 20,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 20
     }
    ],
    "source": [
@@ -603,14 +603,14 @@
    },
    "outputs": [
     {
+     "output_type": "error",
      "ename": "ValueError",
      "evalue": "substring not found",
-     "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-21-4cbe6ee9b0eb>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mline\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'bear'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m: substring not found"
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-21-adf599eb4c79>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mline\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'bear'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mValueError\u001b[0m: substring not found"
      ]
     }
    ],
@@ -934,20 +934,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'3.14159'"
       ]
      },
-     "execution_count": 32,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 2
     }
    ],
    "source": [
@@ -1015,6 +1015,33 @@
    ]
   },
   {
+   "source": [
+    "Since the release of version 3.6, *f-strings* or *'formatted string literals'* are a nicer alternative to format strings. You can read more about it in [PEP 498](https://www.python.org/dev/peps/pep-0498/). With *f-string* representation the above line becomes:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "'The value of pi is 3.14159'"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 5
+    }
+   ],
+   "source": [
+    "f\"The value of pi is {pi}\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1074,46 +1101,101 @@
    ]
   },
   {
+   "source": [
+    "With *f-strings* the above statement can be rewritten as:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "'First letter: A. Last letter: Z.'"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 7
+    }
+   ],
+   "source": [
+    "first, last = 'A', 'Z'\n",
+    "f\"\"\"First letter: {first}. Last letter: {last}.\"\"\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Finally, for numerical inputs, you can include format codes which control how the value is converted to a string.\n",
-    "For example, to print a number as a floating point with three digits after the decimal point, you can use the following:"
+    "For example, to print a number as a floating point with three digits after the decimal point, you can use either of the following:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'pi = 3.142'"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "pi = 3.142\npi = 3.142\n"
+     ]
     }
    ],
    "source": [
-    "\"pi = {0:.3f}\".format(pi)"
+    "print(\"pi = {0:.3f}\".format(pi))\n",
+    "print(f\"pi = {pi:.3f}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As before, here the \"``0``\" refers to the index of the value to be inserted.\n",
-    "The \"``:``\" marks that format codes will follow.\n",
+    "In both the statements, the \"``:``\" marks that format codes will follow.\n",
     "The \"``.3f``\" encodes the desired precision: three digits beyond the decimal point, floating-point format.\n",
-    "\n",
-    "This style of format specification is very flexible, and the examples here barely scratch the surface of the formatting options available.\n",
-    "For more information on the syntax of these format strings, see the [Format Specification](https://docs.python.org/3/library/string.html#formatspec) section of Python's online documentation."
+    "\n"
    ]
+  },
+  {
+   "source": [
+    "An alternative *f-string* representation of the above statement is as shown below. If debugging using *print* statements, this enables a terse yet clear representation of the variables being tracked."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "pi=3.14159\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{pi=}\")"
+   ]
+  },
+  {
+   "source": [
+    "These two styles of format specification (*.format()* and *f-string*) are very flexible, and the examples here barely scratch the surface of the formatting options available.\n",
+    "For more information on the syntax of these format strings, see the [Format Specification](https://docs.python.org/3/library/string.html#formatspec) section of Python's online documentation."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -2000,7 +2082,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.8.5-final"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added examples of f-string usage to string formatting section.
1. 
f"The value of pi is {pi}"

2. 
first, last = 'A', 'Z'
f"""First letter: {first}. Last letter: {last}."""

3.
f"pi = {pi:.3f}"

4.
print(f"{pi=}")