### PR TITLE
Typo in Control Flow Statements

### DIFF
--- a/07-Control-Flow-Statements.ipynb
+++ b/07-Control-Flow-Statements.ipynb
@@ -81,7 +81,7 @@
     "Note especially the use of colons (``:``) and whitespace to denote separate blocks of code.\n",
     "\n",
     "Python adopts the ``if`` and ``else`` often used in other languages; its more unique keyword is ``elif``, a contraction of \"else if\".\n",
-    "In these conditional clauses, ``elif`` and ``else`` blocks are optional; additionally, you can optinally include as few or as many ``elif`` statements as you would like."
+    "In these conditional clauses, ``elif`` and ``else`` blocks are optional; additionally, you can optionally include as few or as many ``elif`` statements as you would like."
    ]
   },
   {


### PR DESCRIPTION
In the last sentence in the paragraph before the For Loops header: "optinally" corrected to "optionally".